### PR TITLE
Add QoS flags to CLI examples to match offboard_manager subscriber

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,29 +26,31 @@ ros2 launch dexi_offboard offboard_sitl.launch.py
 
 ### 2. Basic Flight Sequence
 
-Once the node is running, you can control the drone using ROS2 topics:
+Once the node is running, you can control the drone using ROS2 topics.
+
+> **Note:** The `offboard_manager` subscriber uses a `BEST_EFFORT` / `TRANSIENT_LOCAL` QoS profile (shared with PX4 `/fmu/*` topics), so `ros2 topic pub` must be invoked with `--qos-reliability best_effort --qos-durability transient_local`. Without these flags the CLI publisher's default `RELIABLE` / `VOLATILE` QoS is incompatible and no messages are delivered (`DURABILITY_QOS_POLICY` warning). The Python examples under `examples/python/` configure the matching QoS in code.
 
 ```bash
 # 1. Start offboard heartbeat (required before other commands)
-ros2 topic pub --once /dexi/offboard_manager dexi_interfaces/msg/OffboardNavCommand "{command: 'start_offboard_heartbeat'}"
+ros2 topic pub --once --qos-reliability best_effort --qos-durability transient_local /dexi/offboard_manager dexi_interfaces/msg/OffboardNavCommand "{command: 'start_offboard_heartbeat'}"
 
 # 2. Arm the vehicle
-ros2 topic pub --once /dexi/offboard_manager dexi_interfaces/msg/OffboardNavCommand "{command: 'arm'}"
+ros2 topic pub --once --qos-reliability best_effort --qos-durability transient_local /dexi/offboard_manager dexi_interfaces/msg/OffboardNavCommand "{command: 'arm'}"
 
 # 3. Takeoff to 2 meters (standard PX4 auto mode)
-ros2 topic pub --once /dexi/offboard_manager dexi_interfaces/msg/OffboardNavCommand "{command: 'takeoff', distance_or_degrees: 2.0}"
+ros2 topic pub --once --qos-reliability best_effort --qos-durability transient_local /dexi/offboard_manager dexi_interfaces/msg/OffboardNavCommand "{command: 'takeoff', distance_or_degrees: 2.0}"
 
 # OR 3. Offboard Takeoff (pure offboard mode with altitude setpoints)
-ros2 topic pub --once /dexi/offboard_manager dexi_interfaces/msg/OffboardNavCommand "{command: 'offboard_takeoff', distance_or_degrees: 2.0}"
+ros2 topic pub --once --qos-reliability best_effort --qos-durability transient_local /dexi/offboard_manager dexi_interfaces/msg/OffboardNavCommand "{command: 'offboard_takeoff', distance_or_degrees: 2.0}"
 
 # 4. Land
-ros2 topic pub --once /dexi/offboard_manager dexi_interfaces/msg/OffboardNavCommand "{command: 'land'}"
+ros2 topic pub --once --qos-reliability best_effort --qos-durability transient_local /dexi/offboard_manager dexi_interfaces/msg/OffboardNavCommand "{command: 'land'}"
 
 # 5. Disarm
-ros2 topic pub --once /dexi/offboard_manager dexi_interfaces/msg/OffboardNavCommand "{command: 'disarm'}"
+ros2 topic pub --once --qos-reliability best_effort --qos-durability transient_local /dexi/offboard_manager dexi_interfaces/msg/OffboardNavCommand "{command: 'disarm'}"
 
 # 6. Stop offboard heartbeat
-ros2 topic pub --once /dexi/offboard_manager dexi_interfaces/msg/OffboardNavCommand "{command: 'stop_offboard_heartbeat'}"
+ros2 topic pub --once --qos-reliability best_effort --qos-durability transient_local /dexi/offboard_manager dexi_interfaces/msg/OffboardNavCommand "{command: 'stop_offboard_heartbeat'}"
 ```
 
 ## Available Commands
@@ -97,45 +99,45 @@ ros2 topic pub --once /dexi/offboard_manager dexi_interfaces/msg/OffboardNavComm
 
 ```bash
 # Start offboard mode
-ros2 topic pub --once /dexi/offboard_manager dexi_interfaces/msg/OffboardNavCommand "{command: 'start_offboard_heartbeat'}"
+ros2 topic pub --once --qos-reliability best_effort --qos-durability transient_local /dexi/offboard_manager dexi_interfaces/msg/OffboardNavCommand "{command: 'start_offboard_heartbeat'}"
 
 # Arm and takeoff
-ros2 topic pub --once /dexi/offboard_manager dexi_interfaces/msg/OffboardNavCommand "{command: 'arm'}"
-ros2 topic pub --once /dexi/offboard_manager dexi_interfaces/msg/OffboardNavCommand "{command: 'takeoff', distance_or_degrees: 3.0}"
+ros2 topic pub --once --qos-reliability best_effort --qos-durability transient_local /dexi/offboard_manager dexi_interfaces/msg/OffboardNavCommand "{command: 'arm'}"
+ros2 topic pub --once --qos-reliability best_effort --qos-durability transient_local /dexi/offboard_manager dexi_interfaces/msg/OffboardNavCommand "{command: 'takeoff', distance_or_degrees: 3.0}"
 
 # Wait for takeoff to complete, then fly a square pattern
 sleep 5
-ros2 topic pub --once /dexi/offboard_manager dexi_interfaces/msg/OffboardNavCommand "{command: 'fly_forward', distance_or_degrees: 5.0}"
+ros2 topic pub --once --qos-reliability best_effort --qos-durability transient_local /dexi/offboard_manager dexi_interfaces/msg/OffboardNavCommand "{command: 'fly_forward', distance_or_degrees: 5.0}"
 sleep 3
-ros2 topic pub --once /dexi/offboard_manager dexi_interfaces/msg/OffboardNavCommand "{command: 'fly_right', distance_or_degrees: 5.0}"
+ros2 topic pub --once --qos-reliability best_effort --qos-durability transient_local /dexi/offboard_manager dexi_interfaces/msg/OffboardNavCommand "{command: 'fly_right', distance_or_degrees: 5.0}"
 sleep 3
-ros2 topic pub --once /dexi/offboard_manager dexi_interfaces/msg/OffboardNavCommand "{command: 'fly_backward', distance_or_degrees: 5.0}"
+ros2 topic pub --once --qos-reliability best_effort --qos-durability transient_local /dexi/offboard_manager dexi_interfaces/msg/OffboardNavCommand "{command: 'fly_backward', distance_or_degrees: 5.0}"
 sleep 3
-ros2 topic pub --once /dexi/offboard_manager dexi_interfaces/msg/OffboardNavCommand "{command: 'fly_left', distance_or_degrees: 5.0}"
+ros2 topic pub --once --qos-reliability best_effort --qos-durability transient_local /dexi/offboard_manager dexi_interfaces/msg/OffboardNavCommand "{command: 'fly_left', distance_or_degrees: 5.0}"
 
 # Land and disarm
 sleep 3
-ros2 topic pub --once /dexi/offboard_manager dexi_interfaces/msg/OffboardNavCommand "{command: 'land'}"
+ros2 topic pub --once --qos-reliability best_effort --qos-durability transient_local /dexi/offboard_manager dexi_interfaces/msg/OffboardNavCommand "{command: 'land'}"
 sleep 5
-ros2 topic pub --once /dexi/offboard_manager dexi_interfaces/msg/OffboardNavCommand "{command: 'disarm'}"
-ros2 topic pub --once /dexi/offboard_manager dexi_interfaces/msg/OffboardNavCommand "{command: 'stop_offboard_heartbeat'}"
+ros2 topic pub --once --qos-reliability best_effort --qos-durability transient_local /dexi/offboard_manager dexi_interfaces/msg/OffboardNavCommand "{command: 'disarm'}"
+ros2 topic pub --once --qos-reliability best_effort --qos-durability transient_local /dexi/offboard_manager dexi_interfaces/msg/OffboardNavCommand "{command: 'stop_offboard_heartbeat'}"
 ```
 
 ### Automated Box Mission
 
 ```bash
 # Start offboard mode and arm
-ros2 topic pub --once /dexi/offboard_manager dexi_interfaces/msg/OffboardNavCommand "{command: 'start_offboard_heartbeat'}"
-ros2 topic pub --once /dexi/offboard_manager dexi_interfaces/msg/OffboardNavCommand "{command: 'arm'}"
+ros2 topic pub --once --qos-reliability best_effort --qos-durability transient_local /dexi/offboard_manager dexi_interfaces/msg/OffboardNavCommand "{command: 'start_offboard_heartbeat'}"
+ros2 topic pub --once --qos-reliability best_effort --qos-durability transient_local /dexi/offboard_manager dexi_interfaces/msg/OffboardNavCommand "{command: 'arm'}"
 
 # Takeoff using offboard mode
-ros2 topic pub --once /dexi/offboard_manager dexi_interfaces/msg/OffboardNavCommand "{command: 'offboard_takeoff', distance_or_degrees: 2.0}"
+ros2 topic pub --once --qos-reliability best_effort --qos-durability transient_local /dexi/offboard_manager dexi_interfaces/msg/OffboardNavCommand "{command: 'offboard_takeoff', distance_or_degrees: 2.0}"
 
 # Optional: Set custom delay between waypoints (default is 1.0 seconds)
-ros2 topic pub --once /dexi/offboard_manager dexi_interfaces/msg/OffboardNavCommand "{command: 'set_mission_delay', distance_or_degrees: 2.0}"
+ros2 topic pub --once --qos-reliability best_effort --qos-durability transient_local /dexi/offboard_manager dexi_interfaces/msg/OffboardNavCommand "{command: 'set_mission_delay', distance_or_degrees: 2.0}"
 
 # Execute automated 5m x 5m box mission at current altitude
-ros2 topic pub --once /dexi/offboard_manager dexi_interfaces/msg/OffboardNavCommand "{command: 'box_mission', distance_or_degrees: 5.0}"
+ros2 topic pub --once --qos-reliability best_effort --qos-durability transient_local /dexi/offboard_manager dexi_interfaces/msg/OffboardNavCommand "{command: 'box_mission', distance_or_degrees: 5.0}"
 
 # The drone will automatically:
 # 1. Fly forward 5m at current altitude → target reached → settle 2.0s
@@ -144,9 +146,9 @@ ros2 topic pub --once /dexi/offboard_manager dexi_interfaces/msg/OffboardNavComm
 # 4. Fly left 5m back to start at current altitude → target reached → mission complete!
 
 # Land and disarm
-ros2 topic pub --once /dexi/offboard_manager dexi_interfaces/msg/OffboardNavCommand "{command: 'land'}"
-ros2 topic pub --once /dexi/offboard_manager dexi_interfaces/msg/OffboardNavCommand "{command: 'disarm'}"
-ros2 topic pub --once /dexi/offboard_manager dexi_interfaces/msg/OffboardNavCommand "{command: 'stop_offboard_heartbeat'}"
+ros2 topic pub --once --qos-reliability best_effort --qos-durability transient_local /dexi/offboard_manager dexi_interfaces/msg/OffboardNavCommand "{command: 'land'}"
+ros2 topic pub --once --qos-reliability best_effort --qos-durability transient_local /dexi/offboard_manager dexi_interfaces/msg/OffboardNavCommand "{command: 'disarm'}"
+ros2 topic pub --once --qos-reliability best_effort --qos-durability transient_local /dexi/offboard_manager dexi_interfaces/msg/OffboardNavCommand "{command: 'stop_offboard_heartbeat'}"
 ```
 
 ## Prerequisites

--- a/examples/cli/basic_flight.sh
+++ b/examples/cli/basic_flight.sh
@@ -35,7 +35,7 @@ send_command() {
     local description=$3
 
     echo -e "${GREEN}$description${NC}"
-    ros2 topic pub --once $TOPIC dexi_interfaces/msg/OffboardNavCommand "{command: '$command', distance_or_degrees: $value}"
+    ros2 topic pub --once --qos-reliability best_effort --qos-durability transient_local $TOPIC dexi_interfaces/msg/OffboardNavCommand "{command: '$command', distance_or_degrees: $value}"
 
     # Wait for command to be processed
     sleep 2
@@ -96,15 +96,15 @@ cleanup() {
 
     # Emergency landing sequence
     echo -e "${YELLOW}Sending emergency land command...${NC}"
-    ros2 topic pub --once $TOPIC dexi_interfaces/msg/OffboardNavCommand "{command: 'land'}" || true
+    ros2 topic pub --once --qos-reliability best_effort --qos-durability transient_local $TOPIC dexi_interfaces/msg/OffboardNavCommand "{command: 'land'}" || true
     sleep 5
 
     echo -e "${YELLOW}Sending disarm command...${NC}"
-    ros2 topic pub --once $TOPIC dexi_interfaces/msg/OffboardNavCommand "{command: 'disarm'}" || true
+    ros2 topic pub --once --qos-reliability best_effort --qos-durability transient_local $TOPIC dexi_interfaces/msg/OffboardNavCommand "{command: 'disarm'}" || true
     sleep 2
 
     echo -e "${YELLOW}Stopping offboard heartbeat...${NC}"
-    ros2 topic pub --once $TOPIC dexi_interfaces/msg/OffboardNavCommand "{command: 'stop_offboard_heartbeat'}" || true
+    ros2 topic pub --once --qos-reliability best_effort --qos-durability transient_local $TOPIC dexi_interfaces/msg/OffboardNavCommand "{command: 'stop_offboard_heartbeat'}" || true
 
     echo -e "${RED}Emergency shutdown completed.${NC}"
     exit 1

--- a/examples/cli/manual_commands.sh
+++ b/examples/cli/manual_commands.sh
@@ -29,7 +29,7 @@ send_dexi_command() {
     local description=${3:-"Sending command: $command"}
 
     echo -e "${GREEN}$description${NC}"
-    ros2 topic pub --once $TOPIC dexi_interfaces/msg/OffboardNavCommand "{command: '$command', distance_or_degrees: $value}"
+    ros2 topic pub --once --qos-reliability best_effort --qos-durability transient_local $TOPIC dexi_interfaces/msg/OffboardNavCommand "{command: '$command', distance_or_degrees: $value}"
 }
 
 # =============================================================================

--- a/examples/cli/teleop_test.sh
+++ b/examples/cli/teleop_test.sh
@@ -29,7 +29,7 @@ send_command() {
     local description=$3
 
     echo -e "${GREEN}$description${NC}"
-    ros2 topic pub --once $TOPIC dexi_interfaces/msg/OffboardNavCommand "{command: '$command', distance_or_degrees: $value}"
+    ros2 topic pub --once --qos-reliability best_effort --qos-durability transient_local $TOPIC dexi_interfaces/msg/OffboardNavCommand "{command: '$command', distance_or_degrees: $value}"
     sleep 2
 }
 

--- a/src/keyboard_teleop.cpp
+++ b/src/keyboard_teleop.cpp
@@ -189,8 +189,9 @@ void KeyboardTeleop::printInstructions()
     std::cout << "  Q / q  : Quit teleop" << std::endl;
     std::cout << std::endl;
     std::cout << "NOTE: Make sure offboard heartbeat is started!" << std::endl;
-    std::cout << "      ros2 topic pub --once /dexi/offboard_manager \\" << std::endl;
-    std::cout << "        dexi_interfaces/msg/OffboardNavCommand \\" << std::endl;
+    std::cout << "      ros2 topic pub --once \\" << std::endl;
+    std::cout << "        --qos-reliability best_effort --qos-durability transient_local \\" << std::endl;
+    std::cout << "        /dexi/offboard_manager dexi_interfaces/msg/OffboardNavCommand \\" << std::endl;
     std::cout << "        \"{command: 'start_offboard_heartbeat'}\"" << std::endl;
     std::cout << std::string(50, '=') << std::endl;
     std::cout << "Ready for input (no need to press Enter)..." << std::endl;


### PR DESCRIPTION
## Summary

- Adds `--qos-reliability best_effort --qos-durability transient_local` to every `ros2 topic pub` example in `README.md`, the three scripts under `examples/cli/`, and the help text printed by `keyboard_teleop`.
- Adds a short note to the Quick Start section of `README.md` explaining why the flags are required.

## Why

The `offboard_manager` command subscriber uses `BEST_EFFORT` + `TRANSIENT_LOCAL` QoS (introduced in ce4fd7e, consistent with the PX4 `/fmu/*` topics the node already talks to). Commit 429a61b updated the Python examples to match and added a troubleshooting note to `examples/README.md`, but the main `README.md`, the `examples/cli/*.sh` scripts, and the `keyboard_teleop` help text were missed.

Without the matching flags, `ros2 topic pub` uses its default `RELIABLE` + `VOLATILE` QoS and the user sees:

> New publisher discovered on topic '/dexi/offboard_manager', offering incompatible QoS. No messages will be sent to it. Last incompatible policy: DURABILITY_QOS_POLICY

…and the command is silently dropped. This was reported against a fresh OS re-flash following the README as-is.

## Non-goals

No code changes to `px4_offboard_manager.cpp`. The existing QoS profile is intentional and is already matched by downstream consumers (Python examples, rosbridge clients such as droneblocks-view). Flipping the node to default QoS would be a breaking change for those integrations.

## Test plan

- [ ] `ros2 topic pub --once --qos-reliability best_effort --qos-durability transient_local /dexi/offboard_manager dexi_interfaces/msg/OffboardNavCommand "{command: 'start_offboard_heartbeat'}"` delivers without the `DURABILITY_QOS_POLICY` warning.
- [ ] `examples/cli/basic_flight.sh` runs end-to-end in SITL.
- [ ] `examples/cli/manual_commands.sh` sourced and `test_connection` + `quick_takeoff` work in SITL.
- [ ] `keyboard_teleop` help text displays the updated command.