### PR TITLE
Preserve position target on phantom zero-velocity command

### DIFF
--- a/src/px4_offboard_manager.cpp
+++ b/src/px4_offboard_manager.cpp
@@ -757,9 +757,13 @@ void PX4OffboardManager::sendOffboardHeartbeat()
 // Velocity control methods
 void PX4OffboardManager::setVelocityBody(float vx, float vy, float vz, float yaw_rate_deg)
 {
-    // If all inputs are near zero, stop velocity mode
+    // All-zero input only means "stop" if we are currently in velocity mode.
+    // A phantom zero from a stale frontend loop must not clobber an active
+    // position target (e.g. an in-progress takeoff).
     if (std::abs(vx) < 0.01f && std::abs(vy) < 0.01f && std::abs(vz) < 0.01f && std::abs(yaw_rate_deg) < 0.1f) {
-        stopVelocity();
+        if (control_mode_ == ControlMode::VELOCITY) {
+            stopVelocity();
+        }
         return;
     }
 


### PR DESCRIPTION
## Summary

`setVelocityBody()` interpreted any all-near-zero input as "stop and hold," calling `stopVelocity()` which captures the current position as the hold target. After this change a zero-velocity message is only treated as a stop when `control_mode_` is already `VELOCITY` — so an active position target (takeoff, `fly_forward`, `goto_ned`) cannot be clobbered by an out-of-band zero-velocity heartbeat.

## Why

After `dexi-sim-ftw` started running the new `dexi_platform_params` node, the GCS frontend reads `dexi_keyboard_control: true` for sim deployments and mounts `KeyboardControl.vue`. In some browser focus / key-release edge cases the component's `setInterval(sendVelocityCommand, 100)` keeps running with `activeKeys` empty, publishing `set_velocity_body(0,0,0,0)` to `/dexi/offboard_manager` at 10Hz.

The first phantom arrives ~100–140ms after `offboard_takeoff` is issued — exactly long enough for `target_z_` to be set to the climb altitude and then immediately captured back to ground z by `stopVelocity()`. Effect: drone arms, offboard mode engages, but `trajectory_setpoint` stays at ground z. Drone stays on the ground; service returns success because `offboard_takeoff` doesn't wait for altitude.

Confirmed against a running Hetzner sim container (`docker logs dexi-sim-ftw-ros2-dev-1`):

```
[…] Starting offboard takeoff to 2.00 meters
[…] Offboard takeoff setpoint: target_z=-2.16 (climb 2.00 meters)
[…] Received command: set_velocity_body          ← 137ms later
[…] Received command: set_velocity_body          ← ~10Hz flood begins
…
```

There is a parallel cleanup needed in `dexi-droneblocks` `KeyboardControl.vue` to stop the phantom publishes at the source — but this fix is the right server-side defense regardless: a zero-velocity heartbeat from any caller should not be able to clobber an in-progress takeoff.

## Test plan

Reproduced and verified in a local `docker compose` stack (matches Hetzner image).

**Before fix:**
```
After offboard_takeoff 2.0m   → trajectory_setpoint position[2] = -1.99
After phantom (0,0,0,0)        → trajectory_setpoint position[2] = -0.018  ← target wiped
```

**After fix (rebuilt binary, fresh node):**
```
After offboard_takeoff 2.0m   → trajectory_setpoint position[2] = -2.000
After phantom (0,0,0,0)        → trajectory_setpoint position[2] = -2.000  ← preserved ✓
```

**Regression — legitimate velocity flow still works:**
```
After set_velocity_body(0,0,-1,0)  → control_mode_ = VELOCITY (climb command)
After set_velocity_body(0,0, 0,0)  → control_mode_ = POSITION at current pos ✓
```

- [x] Bug reproduced locally before fix
- [x] Fix verified locally (`trajectory_setpoint` preserved across phantom)
- [x] Velocity → zero stop still captures position correctly
- [ ] Verify on Hetzner sim after `Build Sim ROS2 Image` runs and `:latest` is redeployed
- [ ] Verify on hardware (DEXI-5/Pi 5) — flow is POSITION-mode-only on hardware so this is strict improvement